### PR TITLE
Added ability to send empty response and error logs for invalid parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ const DOC_MIME_TYPES = {
 };
 
 const RESPONSE_TYPE_REDIRECT = "redirect";
+const RESPONSE_TYPE_EMPTY = 'empty';
 
 var DOCS_FILES = {};
 
@@ -722,6 +723,9 @@ module.exports = {
                                     this.writeHeaders(res, STATUS_CODE_SUCCESS, response.content_type, response.content_disposition);
                                     
                                     res.write(response.content);
+                                    res.end();
+                                } else if (response && response.type === RESPONSE_TYPE_EMPTY) {
+                                    this.writeHeaders(res, STATUS_CODE_SUCCESS);
                                     res.end();
                                 } else {
                                     this.writeHeaders(res, STATUS_CODE_SUCCESS, CONTENT_TYPE_JSON);

--- a/index.js
+++ b/index.js
@@ -725,7 +725,7 @@ module.exports = {
                                     res.write(response.content);
                                     res.end();
                                 } else if (response && response.type === RESPONSE_TYPE_EMPTY) {
-                                    this.writeHeaders(res, STATUS_CODE_SUCCESS);
+                                    this.writeHeaders(res, STATUS_CODE_SUCCESS, CONTENT_TYPE_JSON);
                                     res.end();
                                 } else {
                                     this.writeHeaders(res, STATUS_CODE_SUCCESS, CONTENT_TYPE_JSON);

--- a/index.js
+++ b/index.js
@@ -737,6 +737,9 @@ module.exports = {
                             }
                         } else {
                             // Invalid/missing params
+                            console.error(new Error('Invalid parameters'), {
+                                errors: validatedParams.errors
+                            });
                             this.writeHeaders(res, ERROR_400_BAD_REQUEST, CONTENT_TYPE_JSON);
                             res.write(JSON.stringify(validatedParams.errors));
                             res.end();


### PR DESCRIPTION
Allows us to respond to slack api requests without having to send a response. Realised this helps when generating the images as you can upload them to a slack channel directly and you don't need to send a content response back from the slack slash command request.